### PR TITLE
Change the name of cifar10_train directory

### DIFF
--- a/cifar10_train.py
+++ b/cifar10_train.py
@@ -52,7 +52,7 @@ import cifar10
 
 FLAGS = tf.app.flags.FLAGS
 
-tf.app.flags.DEFINE_string('train_dir', 'cifar10_trian/',
+tf.app.flags.DEFINE_string('train_dir', 'cifar10_train/',
                            """Directory where to write event logs """
                            """and checkpoint.""")
 tf.app.flags.DEFINE_integer('max_steps', 20000,


### PR DESCRIPTION
A little problem. The original name is "cifar10_trian", and this will cause a mistake in cifar10_eval.py when reading checkpoint file